### PR TITLE
Improve testing for Zapier app.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
   "extends": "eslint:recommended",
   "env": {
     "es6": true,
-    "node": true
+    "node": true,
+    "mocha": true
   },
   "rules": {
     "comma-dangle": ["error", "always-multiline"],

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .environment
 .env
 .zapierapprc
+config.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+singleQuote: true
+printWidth: 200
+trailingComma: es5

--- a/authentication.js
+++ b/authentication.js
@@ -20,8 +20,8 @@ module.exports = {
       method: 'GET',
       url: `${OAUTH_URL}/authorize`,
       params: {
-        client_id: '{{process.env.CLIENT_ID}}',
-        redirect_uri: '{{config.REDIRECT_URI}}',
+        client_id: process.env.CLIENT_ID,
+        redirect_uri: config.REDIRECT_URI,
         response_type: 'code id_token',
         scope: 'full',
       },
@@ -32,9 +32,9 @@ module.exports = {
       url: `${OAUTH_URL}/token`,
       body: {
         code: '{{bundle.inputData.code}}',
-        client_id: '{{process.env.CLIENT_ID}}',
-        client_secret: '{{process.env.CLIENT_SECRET}}',
-        redirect_uri: '{{config.REDIRECT_URI}}',
+        client_id: process.env.CLIENT_ID,
+        client_secret: process.env.CLIENT_SECRET,
+        redirect_uri: config.REDIRECT_URI,
         grant_type: 'authorization_code',
       },
       headers: {
@@ -48,9 +48,9 @@ module.exports = {
       url: `${OAUTH_URL}/token`,
       body: {
         code: '{{bundle.inputData.code}}',
-        client_id: '{{process.env.CLIENT_ID}}',
-        client_secret: '{{process.env.CLIENT_SECRET}}',
-        redirect_uri: '{{config.REDIRECT_URI}}',
+        client_id: process.env.CLIENT_ID,
+        client_secret: process.env.CLIENT_SECRET,
+        redirect_uri: config.REDIRECT_URI,
         grant_type: 'refresh_token',
       },
       headers: {

--- a/authentication.js
+++ b/authentication.js
@@ -1,142 +1,73 @@
 'use strict';
 
-const platform = require('./config').PLATFORM;
-const REDIRECT_URI = require('./config').REDIRECT_URI;
-const OAUTH_URL = `https://${platform}/oauth`;
+const config = require('./config');
+const OAUTH_URL = `https://${config.PLATFORM}/oauth`;
 
-//Construction of the authorization url for Coveo. the url should come out to be roughly
-// to be the following depending on which platform is being used: https://platform.cloud.coveo.com/oauth/authorize?client_id=CLIENT_ID&redirect_uri=REDIRECT_URI/&response_type=code id_token&scope=full 
-const getAuthorizeURL = () => {
-  let url = `${OAUTH_URL}/authorize`;
-
-  const urlParts = [
-    `client_id=${process.env.CLIENT_ID}`,
-    'redirect_uri=' + encodeURI(REDIRECT_URI),
-    'response_type=code id_token',
-    'scope=full',
-  ];
-
-  //Join components of the url together into one
-  const finalUrl = `${url}?${urlParts.join('&')}`;
-
-  return finalUrl;
-
-};
-
-//Function is pretty self-explanatory. Sends a request to Coveo for an access_token and refresh_token.
-//This function is almost identical to refreshAccessToken function, but Zapier requires the two functions be defined 
-//separately. Combining the two functions may be possible.
-const getAccessToken = (z, bundle) => {
-  let url = `${OAUTH_URL}/token`;
-
-  //Set up components to be sent to Coveo for access_token
-  const body = {
-    code: bundle.inputData.code,
-    refresh_token: bundle.authData.refresh_token,
-    redirect_uri: REDIRECT_URI,
-    grant_type: 'authorization_code',
-    response_type: 'token id_token',
-  };
-
-  //Send request for token
-  const promise = z.request(url, {
-    method: 'POST',
-    body,
-    headers: {
-      'content-type': 'application/x-www-form-urlencoded',
-      'Authorization': 'Basic ' + Buffer.from(process.env.CLIENT_ID + ':' + process.env.CLIENT_SECRET).toString('base64'), 
-    },
-  });
-
-  //Get the response, handle any errors, and save the access/refresh tokens for use in any requests needed to Coveo.
-  return promise.then((response) => {
-    if (response.status !== 200) {
-      throw new Error('Error fetching access token: ' + z.JSON.parse(response.content).message + ' Error Code: ' + response.status);
-    }
-
-    const result = z.JSON.parse(response.content);
-    
-    return {
-      access_token: result.access_token,
-      refresh_token: result.refresh_token,
-      id_token: result.id_token,
-    };
-  });
-};
-
-//Almost identical to getAccessToken, Zapier just requires this be defined separately so auto refresh triggers
-//can be carried out. Can combine with getAccessToken in the future.
-const refreshAccessToken = (z, bundle) => {
-  let url = `${OAUTH_URL}/token`;
-
-  //Set up components to be sent to Coveo for refresh_token
-  const body = {
-    code: bundle.inputData.code,
-    refresh_token: bundle.authData.refresh_token,
-    redirect_uri: REDIRECT_URI,
-    grant_type: 'refresh_token',
-    response_type: 'token id_token',
-  };
-
-  //Send request for token
-  const promise = z.request(url, {
-    method: 'POST',
-    body,
-    headers: {
-      'content-type': 'application/x-www-form-urlencoded',
-      'Authorization': 'Basic ' + Buffer.from(process.env.CLIENT_ID + ':' + process.env.CLIENT_SECRET).toString('base64'), 
-    },
-  });
-
-  //Get the response, handle any errors, and save the access/refresh tokens for use in any requests needed to Coveo.
-  return promise.then((response) => {
-    if (response.status !== 200) {
-      throw new Error('Error fetching refresh token: ' + z.JSON.parse(response.content).message + ' Error Code: ' + response.status);
-    }
-
-    const result = z.JSON.parse(response.content);
-    
-    return {
-      access_token: result.access_token,
-      refresh_token: result.refresh_token,
-      id_token: result.id_token,
-    };
-  });
-};
-
-// The test call Zapier makes to ensure an access token is valid
-// UX TIP: Hit an endpoint that always returns data with valid credentials,
-// like a /profile or /me endpoint. That way the success/failure is related to
-// the token and not because the user didn't happen to have a recently created record.
-const testAuth = (z) => {
-  //Test call to Coveo that only requires an access_token, just for testing the token.
-  const promise = z.request({
-    url: `https://${platform}/rest/templates/apikeys`,
-  });
-
-  //Handle response
-  return promise.then((response) => {
-    if (response.status >= 401) {
-      throw new Error('Error occured testing authentication: ' + z.JSON.parse(response.content).message + ' Error Code: ' + response.status);
-    }
-    return z.JSON.parse(response.content);
-  });
-};
+let basicToken = Buffer.from(process.env.CLIENT_ID + ':' + process.env.CLIENT_SECRET).toString('base64');
 
 module.exports = {
   type: 'oauth2',
-  connectionLabel: '(your-email-here)',
-  //oauth2Config data structure is how Zapier determines what to call when managing the ouath. The authorization url construction is
-  //called when needed in authorizeUrl, whenever a access/refresh token is needed it calls getAccessToken, and whenever a 401 error occurs
-  //it knows to call autoRefresh (which calls refreshAccessToken).
-  //See the following: https://zapier.com/developer/documentation/v2/authentication/
+  // oauth2Config data structure is how Zapier determines what to call when managing the oauth. The authorization url construction is
+  // called when needed in authorizeUrl, whenever a access/refresh token is needed it calls getAccessToken, and whenever a 401 error occurs
+  // it knows to call autoRefresh (which calls refreshAccessToken).
+
+  // See the followings:
+  // https://zapier.com/developer/documentation/v2/oauth-v2/
   // https://zapier.github.io/zapier-platform-cli/?utm_source=zapier.com&utm_medium=referral&utm_campaign=zapier#oauth2
+
   oauth2Config: {
-    authorizeUrl: getAuthorizeURL,
-    getAccessToken,
-    refreshAccessToken,
+    authorizeUrl: {
+      method: 'GET',
+      url: `${OAUTH_URL}/authorize`,
+      params: {
+        client_id: '{{process.env.CLIENT_ID}}',
+        redirect_uri: '{{config.REDIRECT_URI}}',
+        response_type: 'code id_token',
+        scope: 'full',
+      },
+    },
+
+    getAccessToken: {
+      method: 'POST',
+      url: `${OAUTH_URL}/token`,
+      body: {
+        code: '{{bundle.inputData.code}}',
+        client_id: '{{process.env.CLIENT_ID}}',
+        client_secret: '{{process.env.CLIENT_SECRET}}',
+        redirect_uri: '{{config.REDIRECT_URI}}',
+        grant_type: 'authorization_code',
+      },
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${basicToken}`,
+      },
+    },
+
+    refreshAccessToken: {
+      method: 'POST',
+      url: `${OAUTH_URL}/token`,
+      body: {
+        code: '{{bundle.inputData.code}}',
+        client_id: '{{process.env.CLIENT_ID}}',
+        client_secret: '{{process.env.CLIENT_SECRET}}',
+        redirect_uri: '{{config.REDIRECT_URI}}',
+        grant_type: 'refresh_token',
+      },
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${basicToken}`,
+      },
+    },
+
     // Set so Zapier automatically checks for 401s and calls refreshAccessToken
     autoRefresh: true,
   },
-  test: testAuth,
+
+  // The test call Zapier makes to ensure an access token is valid
+  // UX TIP: Hit an endpoint that always returns data with valid credentials,
+  // like a /profile or /me endpoint. That way the success/failure is related to
+  // the token and not because the user didn't happen to have a recently created record.
+  test: {
+    url: `https://${config.PLATFORM}/rest/organizations`,
+  },
 };

--- a/creates/delete.js
+++ b/creates/delete.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const messages = require('../messages');
 const deleteResource = require('../resources/delete');
 const deleteHandler = require('../resources/deleteHandler');
 
@@ -8,13 +7,11 @@ const deleteHandler = require('../resources/deleteHandler');
 //a handoff to the deleteHandler file to handle the creation of a delete request, sending it
 //to Coveo, then handling the appropriate response content.
 const createDelete = (z, bundle) => {
-
   bundle.inputData['documentId'] = bundle.inputData.docId.replace(/[?&#]/g, '=');
   bundle.inputData['uri'] = bundle.inputData.docId;
   delete bundle.inputData.docId;
 
   return deleteHandler.handleDeleteCreation(z, bundle);
-
 };
 
 module.exports = {
@@ -53,7 +50,8 @@ module.exports = {
         required: true,
         type: 'string',
         label: 'Document ID',
-        helpText: 'The ID of the document you wish to delete. Children of the document ID supplied will also be deleted. Children of the document that are indexed have the same url with /file# appended to it when pushed through Zapier. If you wish to delete specific children, simply add /file#. Example: `https://example.com/file2`.',
+        helpText:
+          'The ID of the document you wish to delete. Children of the document ID supplied will also be deleted. Children of the document that are indexed have the same url with /file# appended to it when pushed through Zapier. If you wish to delete specific children, simply add /file#. Example: `https://example.com/file2`.',
       },
       {
         key: 'title',

--- a/creates/push.js
+++ b/creates/push.js
@@ -65,7 +65,7 @@ module.exports = {
         type: 'string',
         label: 'Document ID',
         helpText:
-          'The main URL to your document or page you wish to push. This MUST be a url. If no urls are provided, most apps provide and ID or some other sort of identifier. You can do something like this: gmail://EMAIL_ID.',
+          'The ID of the document you want to use in the index. This MUST be in a url form. You can use the original url or create your own identifier like this: gmail://EMAIL_ID.',
       },
       {
         key: 'title',

--- a/creates/push.js
+++ b/creates/push.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const messages = require('../messages');
 const pushResource = require('../resources/push');
 const pushHandler = require('../resources/pushHandler');
 const _ = require('lodash');
@@ -9,7 +8,6 @@ const _ = require('lodash');
 //a handoff to the pushHandler file to handle the creation of a push request, sending it
 //to Coveo, then handling the appropriate response content.
 const createNewPush = (z, bundle) => {
-
   //Set the field names as properties and the values of these new properties
   //to what the user put as the content for these fields. Not sure if there's a better
   //way of doing this.
@@ -25,7 +23,6 @@ const createNewPush = (z, bundle) => {
 
   //Move on to handling the push process
   return pushHandler.handlePushCreation(z, bundle);
-
 };
 
 // We recommend writing your creates separate like this and rolling them
@@ -67,7 +64,8 @@ module.exports = {
         required: true,
         type: 'string',
         label: 'Document ID',
-        helpText: 'The main URL to your document or page you wish to push. This MUST be a url. If no urls are provided, most apps provide and ID or some other sort of identifier. You can do something like this: gmail://EMAIL_ID.',
+        helpText:
+          'The main URL to your document or page you wish to push. This MUST be a url. If no urls are provided, most apps provide and ID or some other sort of identifier. You can do something like this: gmail://EMAIL_ID.',
       },
       {
         key: 'title',
@@ -81,14 +79,16 @@ module.exports = {
         required: false,
         type: 'string',
         label: 'File',
-        helpText: 'The main content you want extracted into the source. This can be a URL or a file. Zapier displays files as (Exists but not shown). This will always be the content of the push submission if it does not fail or if the input supplied does not require authorization (i.e. a gmail email link). If you wish to push multiple files at once, .zip, .tar, .tar.gz, and .tar.bz2 are supported. The files in the archive file will be extracted and pushed to the source.', 
+        helpText:
+          'The main content you want extracted into the source. This can be a URL or a file. Zapier displays files as (Exists but not shown). This will always be the content of the push submission if it does not fail or if the input supplied does not require authorization (i.e. a gmail email link). If you wish to push multiple files at once, .zip, .tar, .tar.gz, and .tar.bz2 are supported. The files in the archive file will be extracted and pushed to the source.',
       },
       {
         key: 'data',
         required: false,
         type: 'string',
         label: 'Plain Text',
-        helpText: 'The main content you want extracted into the source as plain text. This can be text of the file, free text, or a mix of both. Use this if no files or urls for the File field are supplied and you want content to be extracted with your push source. Will only be extracted if File field fails or is not supplied. If niether this nor the File field have any content, then no content will be extracted in the source. If both are supplied, then both will be pushed as a batch.', 
+        helpText:
+          'The main content you want extracted into the source as plain text. This can be text of the file, free text, or a mix of both. Use this if no files or urls for the File field are supplied and you want content to be extracted with your push source. Will only be extracted if File field fails or is not supplied. If niether this nor the File field have any content, then no content will be extracted in the source. If both are supplied, then both will be pushed as a batch.',
       },
       {
         key: 'field1',
@@ -149,6 +149,5 @@ module.exports = {
     // outputFields: () => { return []; }
     // Alternatively, a static field definition should be provided, to specify labels for the fields
     outputFields: pushResource.outputFields,
-
   },
 };

--- a/test/authentication.js
+++ b/test/authentication.js
@@ -1,0 +1,38 @@
+const should = require('should');
+const zapier = require('zapier-platform-core');
+
+const App = require('../index');
+const appTester = zapier.createAppTester(App);
+
+describe('basic authentication', () => {
+  before(function() {
+    // Put your test ACCESS_TOKEN in a .env file.
+    // The inject method will load them and make them available to use in your tests.
+    zapier.tools.env.inject();
+
+    should.ok(process.env.ACCESS_TOKEN, 'missing ACCESS_TOKEN');
+  });
+
+  it('Testing refresh token', function(done) {
+    const bundle = {
+      authData: {
+        access_token: 'bad-token',
+      },
+    };
+
+    appTester(App.authentication.test, bundle).catch(err => {
+      should.equal(err.name, 'RefreshAuthError', 'Should get a "RefreshAuthError" error.');
+      done();
+    });
+  });
+
+  it('Testing access token', function() {
+    const bundle = {
+      authData: {
+        access_token: process.env.ACCESS_TOKEN,
+      },
+    };
+
+    return appTester(App.authentication.test, bundle);
+  });
+});

--- a/test/creates/delete.js
+++ b/test/creates/delete.js
@@ -1,8 +1,4 @@
-require('should');
-
-const orgId = 'bryanarnoldzapier9xh3mbas';
-const sourceId = 'slevs7b47ktbrkzfundtc22nvi-bryanarnoldzapier9xh3mbas';
-
+const should = require('should');
 const zapier = require('zapier-platform-core');
 
 const App = require('../../index');
@@ -12,35 +8,34 @@ const appTester = zapier.createAppTester(App);
 //of the source you're testing.
 
 describe('deletes', () => {
-// This must be included in any test file before bundle, as it extracts the
-// authentication data that was exported from the command line.
-  zapier.tools.env.inject();
-  describe('Delete Test', () => {
+  before(function() {
+    // This must be included in any test file before bundle, as it extracts the
+    // authentication data that was exported from the command line.
+    zapier.tools.env.inject();
 
-    it('Delete single document', (done) => {
+    should.ok(process.env.TEST_ORG_ID, 'missing TEST_ORG_ID=some-id in .env');
+    should.ok(process.env.TEST_SOURCE_ID, 'missing TEST_SOURCE_ID=some-id in .env');
+    should.ok(process.env.ACCESS_TOKEN, 'missing ACCESS_TOKEN. Add ACCESS_TOKEN=some-token in .env');
+  });
+
+  describe('Delete Test', function() {
+    it('Delete single document', function() {
       zapier.tools.env.inject();
       const bundle = {
         authData: {
-          
           access_token: process.env.ACCESS_TOKEN,
-          refresh_token: process.env.REFRESH_TOKEN,
-
         },
-  
+
         //Change these when you test
         inputData: {
           docId: 'https://drive.google.com/a/uconn.edu/file/d/1Cau7dNBMMF9ZjNwbsXkSt-m6a_3yTNse/preview=usp=drivesdk',
           title: 'Zapier Delete Test',
-          sourceId,
-          orgId,
+          sourceId: process.env.TEST_SOURCE_ID,
+          orgId: process.env.TEST_ORG_ID,
         },
       };
-      appTester(App.creates.deletes.operation.perform, bundle)
-        .then((result) => {
-          console.log(result);
-          done();
-        })
-        .catch(done);
+
+      return appTester(App.creates.deletes.operation.perform, bundle);
     });
   });
 });

--- a/test/creates/push.js
+++ b/test/creates/push.js
@@ -1,31 +1,35 @@
-require('should');
-
-const orgId = 'bryanarnoldzapier9xh3mbas';
-const sourceId = 'slevs7b47ktbrkzfundtc22nvi-bryanarnoldzapier9xh3mbas';
-
+const should = require('should');
 const zapier = require('zapier-platform-core');
 
 const App = require('../../index');
 const appTester = zapier.createAppTester(App);
 
-//Tests for pushing a document in a push source. Change the inputData to match the credentials
-//of the source you're testing.
+// Tests for pushing a document in a push source. Change the inputData to match the credentials
+// of the source you're testing.
 
-describe('pushes', () => {
-
-  it('Push Test', (done) => {
-    //This must be included in any test file before bundle, as it extracts the
-    //authentication data that was exported from the command line.
+describe('pushes', function() {
+  before(function() {
+    // This must be included in any test file before bundle, as it extracts the
+    // authentication data that was exported from the command line.
     zapier.tools.env.inject();
+
+    should.ok(process.env.TEST_ORG_ID, 'missing TEST_ORG_ID=some-id in .env');
+    should.ok(process.env.TEST_SOURCE_ID, 'missing TEST_SOURCE_ID=some-id in .env');
+    should.ok(process.env.ACCESS_TOKEN, 'missing ACCESS_TOKEN. Add ACCESS_TOKEN=some-token in .env');
+  });
+
+  it('Push Test', function() {
+    this.timeout(10000); // set timeout to 10 seconds
     const bundle = {
       authData: {
         access_token: process.env.ACCESS_TOKEN,
       },
-      //Change this content to match your source and what you want to push when testing
+      // Change this content to match your source and what you want to push when testing
       inputData: {
         docId: 'https://drive.google.com/a/uconn.edu/file/d/1gCo7WwsHuD5qQbmscWClbeaqydpGa3-v/preview?usp=drivesdk',
         title: 'No parent test',
-        content: 'https://zapier.com/engine/hydrate/1625243/.eJx1kD1vgzAQhv-Lh0wFbPwRQIo6pFI7VeqUERFzgIOxwTakSZT_Xqi69qZ733t0w_NAyvhQGQmlqlHBMMlwyugLahToujTVAKhYgwb0gmQHsi97uKGCiJT_ctKaACaU4TZu5OeK9dfKtR4VDzQ7vXZdCKMvkqS2MsIsEjhaNx-31rYaZg_u70cs7bBBPvEgZwdeJqr3kF7mC8Mg2hHGfNyfNc3rvoHJOrMkBpxivu_6cbrw3i-d50Zjq5ppUXlHmoRwmnKWZXibhFBBGctSynie5Zjk2V78U7ZHuz9d_cf8xqev8-Dl6ajPUE23enyvaLS8dgfCiCB7keYiEymmTDDGd3Co7dVoW9W7tj4EN2_mGuuGKqwuvu9rCiroTdYw66DauxoD-BCHysXr-fn8AeMOgSI:1fiRIj:yiiFnRaR_x9fgNpXoVji-A3G16E/',
+        content:
+          'https://zapier.com/engine/hydrate/1625243/.eJx1kD1vgzAQhv-Lh0wFbPwRQIo6pFI7VeqUERFzgIOxwTakSZT_Xqi69qZ733t0w_NAyvhQGQmlqlHBMMlwyugLahToujTVAKhYgwb0gmQHsi97uKGCiJT_ctKaACaU4TZu5OeK9dfKtR4VDzQ7vXZdCKMvkqS2MsIsEjhaNx-31rYaZg_u70cs7bBBPvEgZwdeJqr3kF7mC8Mg2hHGfNyfNc3rvoHJOrMkBpxivu_6cbrw3i-d50Zjq5ppUXlHmoRwmnKWZXibhFBBGctSynie5Zjk2V78U7ZHuz9d_cf8xqev8-Dl6ajPUE23enyvaLS8dgfCiCB7keYiEymmTDDGd3Co7dVoW9W7tj4EN2_mGuuGKqwuvu9rCiroTdYw66DauxoD-BCHysXr-fn8AeMOgSI:1fiRIj:yiiFnRaR_x9fgNpXoVji-A3G16E/',
         field1: 'thumbnail',
         data: '<html><p>Why no work</p></html>',
         field1Content: 'testing thumbnail field',
@@ -33,17 +37,11 @@ describe('pushes', () => {
         field2Content: 'testing additional content field',
         field3: 'downloadlink',
         field3Content: 'download link test',
-        sourceId,
-        orgId,
+        sourceId: process.env.TEST_SOURCE_ID,
+        orgId: process.env.TEST_ORG_ID,
       },
     };
 
-    appTester(App.creates.push.operation.perform, bundle)
-      .then((result) => {
-        console.log(result);
-        done();
-      })
-      .catch(done);
+    return appTester(App.creates.push.operation.perform, bundle);
   });
-
 });


### PR DESCRIPTION
I simplified the OAuth files and tested it out using `zapier test` and by pushing my own version.

I also changed the auth test url, because the one that was used was internal and not accessible to most. 
Removed hardcoded values for orgs and sources in tests, in favor to use `.env`
